### PR TITLE
Changed variable name — compatibility with Haxe 4, `overload` is reserved.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/benmerckx/dotenv.svg?branch=master)](https://travis-ci.org/benmerckx/dotenv)
 
-Loads environment variables into class' statics. Variables will be loaded from a '.env' file, if one exists. Any existing environment variables will not be overwritten (unless specified by the `overload` option).
+Loads environment variables into class' statics. Variables will be loaded from a '.env' file, if one exists. Any existing environment variables will not be overwritten (unless specified by the `overloaded` option).
 
 ```haxe
 class DatabaseConfig {
@@ -64,7 +64,7 @@ Init takes these options:
 
 ```haxe
 typedef EnvOptions = {
-	?overload: Bool, // Overwrite existing environment variables by the .env file
+	?overloaded: Bool, // Overwrite existing environment variables by the .env file
 	?path: String,   // Specify a different path for loading the file
 	?throws: Bool    // Defaults to true, throws if a variable is missing
 }

--- a/src/dotenv/Env.hx
+++ b/src/dotenv/Env.hx
@@ -9,7 +9,7 @@ using StringTools;
 using haxe.macro.Type.MetaAccess;
 
 typedef EnvOptions = {
-	?overload: Bool,
+	?overloaded: Bool,
 	?path: String,
 	?throws: Bool
 }
@@ -38,8 +38,8 @@ class Env {
 			options = {};
 		if (options.path == null)
 			options.path = '.env';
-		if (options.overload == null)
-			options.overload = false;
+		if (options.overloaded == null)
+			options.overloaded = false;
 		if (options.throws == null)
 			options.throws = true;
 		
@@ -62,7 +62,7 @@ class Env {
 								: null;
 							}
 						
-					if (options.overload)
+					if (options.overloaded)
 						assignments.push(macro @:pos(field.pos) {
 							var t = Sys.getEnv($nameStr);
 							if (parsed.exists($v{name}))
@@ -120,7 +120,7 @@ class Env {
 			if (matcher.match(line)) {
 				var key = matcher.matched(1).trim(),
 					value = matcher.matched(2);
-				if (!options.overload && Sys.getEnv(key) != null) 
+				if (!options.overloaded && Sys.getEnv(key) != null) 
 					continue;
 				value = value == null ? '' : value;
 				value = value.trim();

--- a/tests/RunTests.hx
+++ b/tests/RunTests.hx
@@ -13,7 +13,7 @@ class EnvLoad {
 	@:default(3306)
 	public static var DEFAULTVAL: Int;
 	
-	static function __init__() Env.init({overload: true});
+	static function __init__() Env.init({overloaded: true});
 }
 
 @colorize


### PR DESCRIPTION
Not sure about this, because it's a breaking change... but I don't know a better solution, if any exists 😅 .